### PR TITLE
Add ISO C90 to GPG 1.4 compilation to avoid compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ This technique has been demonstrated against the modular exponentiation
 procedure in GnuPG pre-1.4.14, which allows an attacker to extract the private
 RSA exponent from cache timing data.
 
+## Dependencies
+For the graph plot it uses **matplotlib**.
+
+For Ubuntu users:
+
+```
+$sudo apt-get install python-matplotlib
+```
+
+To speed up gpg key generation install **rng-tools** but it is not mandatory.
+
+For Ubuntu users:
+
+```
+$sudo apt-get install rng-tools
+```
+
 ## Setting up GPG 1.4.12
 As a proof of concept, we attacked GPG 1.4.12. To set this up, there are a few
 build scripts in the `built_gpg/` directory. On OS X, run:
@@ -33,12 +50,16 @@ $ brew install gnupg.rb
 On Linux (and also on OS X if you don't want to use Homebrew):
 
 ```
-$ ./install_locally.sh
+$ ./build_gpg/install_locally.sh
 ```
 
 Of course, you should never run arbitrary executable code from the Internet.
 You should verify that the scripts do what they are expected to do (they're
-pretty short).
+pretty short). A dummy RSA key will be generated according to the parameters in the **keyparams** file and added to the keyring. Do not forget to remove it after usgae:
+
+```
+$gpg --delete-secret-and-public-keys Flush
+```
 
 ## Running our code
 Run `make` first.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ ./build_gpg/install_locally.sh
 
 Of course, you should never run arbitrary executable code from the Internet.
 You should verify that the scripts do what they are expected to do (they're
-pretty short). A dummy RSA key will be generated according to the parameters in the **keyparams** file and added to the keyring. Do not forget to remove it after usgae:
+pretty short). A dummy RSA key will be generated according to the parameters in the **keyparams** file and added to the keyring. Do not forget to remove it after usage:
 
 ```
 $gpg --delete-secret-and-public-keys Flush

--- a/build_gpg/install_locally.sh
+++ b/build_gpg/install_locally.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 SHA1HASH=9b78e20328d35525af7b8a9c1cf081396910e937
+SHA256HASH=4f03ca6902aaee79d0eda00eea0fefde7db9eb005d8ffd54fac9806bc24050ec
 GPG_PREFIX=gnupg-1.4.12
 GPG_ARCHIVE=${GPG_PREFIX}.tar.bz2
+HASH=sha256sum
 export CC=gcc   # If building on OS X, you will need apple-gcc42
 export CFLAGS="-g -O2 -std=c89"
 
+# Download GPG 1.4.12
 curl -O http://mirror.switch.ch/ftp/mirror/gnupg/gnupg/${GPG_ARCHIVE}
-shasum -a 1 -c <(echo "${SHA1HASH}  ${GPG_ARCHIVE}")
+shasum -a 256 -c <(echo "${SHA256HASH}  ${GPG_ARCHIVE}")
 
 if [ $? != 0 ]
 then
@@ -22,6 +25,12 @@ fi
 tar xf ${GPG_ARCHIVE}
 rm ${GPG_ARCHIVE}
 
+# Install GPG locally
 cd ${GPG_PREFIX}
 ./configure --disable-dependency-tracking --disable-asm --prefix=${PWD}
-make && make check # && make install
+make && make check
+
+# Generate the secret key
+cd ..
+./gnupg-1.4.12/g10/gpg --gen-key --batch keyparams
+./gnupg-1.4.12/g10/gpg --import flushreload.sec

--- a/build_gpg/install_locally.sh
+++ b/build_gpg/install_locally.sh
@@ -3,7 +3,7 @@ SHA1HASH=9b78e20328d35525af7b8a9c1cf081396910e937
 GPG_PREFIX=gnupg-1.4.12
 GPG_ARCHIVE=${GPG_PREFIX}.tar.bz2
 export CC=gcc   # If building on OS X, you will need apple-gcc42
-export CFLAGS="-g -O2"
+export CFLAGS="-g -O2 -std=c89"
 
 curl -O http://mirror.switch.ch/ftp/mirror/gnupg/gnupg/${GPG_ARCHIVE}
 shasum -a 1 -c <(echo "${SHA1HASH}  ${GPG_ARCHIVE}")
@@ -24,4 +24,4 @@ rm ${GPG_ARCHIVE}
 
 cd ${GPG_PREFIX}
 ./configure --disable-dependency-tracking --disable-asm --prefix=${PWD}
-make && make check && make install
+make && make check # && make install

--- a/keyparams
+++ b/keyparams
@@ -1,0 +1,12 @@
+%echo Generating a RSA key for Flush + Reload test
+     Key-Type: RSA
+     Key-Length: 2048
+     Name-Real: Flush Reload
+     Name-Comment: For test only
+     Name-Email: flush.reload@cache.bar
+     Expire-Date: 0
+     %no-protection
+     %pubring flushreload.pub
+     %secring flushreload.sec
+     %commit
+     %echo done

--- a/run.sh
+++ b/run.sh
@@ -1,16 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
-GPG=$HOME/gnupg-1.4.12/bin/gpg
-ADDR=addr/osx.txt
+GPG=gnupg-1.4.12/g10/gpg
+ADDR=addr/linu.txt
 MESSAGE=message.txt
 OUT=out.txt
 CYCLES=$1
+KEY=Flush
 
 bin/probe ${GPG} ${ADDR} ${OUT} ${CYCLES} &
 PROBE_PID=$!
 
 sleep 0.01
-(echo "GPG start"; ${GPG} --yes --sign ${MESSAGE}; echo "GPG end") &
+(echo "GPG start"; ${GPG} -u ${KEY} --yes --sign ${MESSAGE}; echo "GPG end") &
 GPG_PID=$!
 
 trap "echo 'Received signal'; kill -TERM ${PROBE_PID} ${GPG_PID}" \


### PR DESCRIPTION
Add "-std=c89" C flag to avoid inline errors during compilation with gcc above 4.3. Since the script is called "install_locally.sh" you may not want to do a "make install" and mess your more recent GPG installation.
